### PR TITLE
feat(E2E): add Playwright browser automation test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node.js / E2E tests
+tests/e2e/node_modules/
+tests/e2e/test-results/
+tests/e2e/package-lock.json
+tests/e2e/dist/
+
+# Agent skills (generated, not committed)
+.agents/
+skills-lock.json

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -1,10 +1,11 @@
 ---
 name: qa-engineer
-description: QA Engineer for PomodoroFocus. Writes and runs unit/integration tests using NUnit, Moq, WebApplicationFactory. Reports test coverage and failures.
+description: QA Engineer for PomodoroFocus. Writes and runs unit/integration tests using NUnit, Moq, WebApplicationFactory, and Playwright CLI for browser automation. Reports test coverage and failures.
 mode: subagent
 tools:
   write: true
   edit: true
+  playwright-cli: true
 ---
 
 # QA Engineer - PomodoroFocus
@@ -49,7 +50,20 @@ Domain → Application → Infrastructure → Web
 |------|-----------|
 | Unit Tests | NUnit 4.3.2, Moq |
 | Integration Tests | Microsoft.AspNetCore.Mvc.Testing (WebApplicationFactory) |
-| Frontend (UI) | Playwright (suggest only) |
+| Browser Automation | playwright-cli (Full capabilities) |
+
+### Playwright CLI Integration
+El skill **playwright-cli** está integrado para realizar testing de navegador. Ver: `.agents/skills/playwright-cli/SKILL.md`
+
+**Herramientas disponibles:**
+- `playwright-cli open` - Abrir navegador
+- `playwright-cli goto <url>` - Navegar a una URL
+- `playwright-cli click <ref>` - Clic en elemento
+- `playwright-cli fill <ref> <text>` - Llenar campo
+- `playwright-cli snapshot` - Capturar estado de la página
+- `playwright-cli eval <js>` - Ejecutar JavaScript
+- `playwright-cli console` - Ver consola del navegador
+- `playwright-cli close` - Cerrar navegador
 
 ## Test Project
 
@@ -85,9 +99,18 @@ public void MethodName_GivenCondition_WhenAction_ThenResult()
 
 ## Commands
 ```bash
+# Unit/Integration Tests
 dotnet test
 dotnet test --filter "Category=Domain"
 dotnet test --logger "console;verbosity=detailed"
+
+# Browser Automation (playwright-cli)
+# Primero inicia la aplicación web en segundo plano
+playwright-cli open http://localhost:5294
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test data"
+playwright-cli close
 ```
 
 ## Workflow
@@ -106,6 +129,57 @@ When a test fails:
    - **Bug in production code** → describe the fix needed, do NOT apply it
    - **Bug in the test** → describe the correction, apply it
 3. Report findings with specific `file.cs:line` references
+
+## Browser Testing Workflow (Playwright CLI)
+
+Para testing de UI/browser, usar playwright-cli integrado:
+
+1. **Iniciar la aplicación web** (si no está corriendo):
+   ```bash
+   dotnet run --project PomodoroFocus/PomodoroFocus.Web
+   ```
+
+2. **Abrir navegador y navegar**:
+   ```bash
+   playwright-cli open http://localhost:5294
+   playwright-cli snapshot
+   ```
+
+3. **Interactuar con la página** (usar refs del snapshot):
+   ```bash
+   # Clics, fills, selects, etc.
+   playwright-cli click e5
+   playwright-cli fill e3 "25"
+   ```
+
+4. **Verificar estado**:
+   ```bash
+   playwright-cli eval "document.querySelector('.timer').textContent"
+   playwright-cli console
+   ```
+
+5. **Cerrar navegador**:
+   ```bash
+   playwright-cli close
+   ```
+
+### Ejemplo: Test de Timer Pomodoro
+```bash
+# Abrir aplicación
+playwright-cli open http://localhost:5294
+playwright-cli snapshot
+
+# Verificar estado inicial del timer
+playwright-cli eval "document.querySelector('.timer-display').textContent"
+
+# Clic en botón Start
+playwright-cli click e10  # botón Start
+playwright-cli snapshot
+
+# Verificar que el timer está corriendo
+playwright-cli eval "document.querySelector('.timer-state').textContent"
+playwright-cli close
+```
 
 ## Subagents
 | Agent | File |

--- a/PomodoroFocus/PomodoroFocus.Application/Services/PomodoroService.cs
+++ b/PomodoroFocus/PomodoroFocus.Application/Services/PomodoroService.cs
@@ -58,10 +58,23 @@ public class PomodoroService : IPomodoroService, IDisposable
         _timer = new System.Timers.Timer(1000);
         _timer.Elapsed += TimerElapsed;
         _configService.OnConfigurationChanged += OnConfigChanged;
+
+        // Initialize RemainingSeconds to pomodoro duration when in Ready state
+        // This ensures the timer displays the configured duration (e.g., 25:00) on initial load
+        if (_session.State == TimerState.Ready)
+        {
+            _session.SetRemainingSeconds(Config.PomodoroDuration * 60);
+        }
     }
 
     private void OnConfigChanged()
     {
+        // When configuration changes while timer is in Ready state, update RemainingSeconds
+        // to reflect the new PomodoroDuration so the display shows the correct time
+        if (_session.State == TimerState.Ready)
+        {
+            _session.SetRemainingSeconds(Config.PomodoroDuration * 60);
+        }
         OnTimerTick?.Invoke();
     }
 

--- a/PomodoroFocus/PomodoroFocus.Domain/Entities/PomodoroSession.cs
+++ b/PomodoroFocus/PomodoroFocus.Domain/Entities/PomodoroSession.cs
@@ -23,7 +23,7 @@ public class PomodoroSession
     public SessionType CurrentSessionType { get; private set; }
 
     /// <summary>
-    /// Gets the number of seconds remaining in the current session. 
+    /// Gets the number of seconds remaining in the current session.
     /// This property is updated as the timer counts down and is used to determine when a session has completed.
     /// </summary>
     public int RemainingSeconds { get; private set; }
@@ -156,5 +156,14 @@ public class PomodoroSession
     {
         CompletedPomodoros = 0;
         // DO NOT change CurrentSessionType here - we are IN a long break session
+    }
+
+    /// <summary>
+    /// Sets the remaining seconds directly. Used by the service to initialize
+    /// the display time before the user starts a session.
+    /// </summary>
+    public void SetRemainingSeconds(int seconds)
+    {
+        RemainingSeconds = seconds;
     }
 }

--- a/PomodoroFocus/skills-lock.json
+++ b/PomodoroFocus/skills-lock.json
@@ -19,6 +19,12 @@
       "skillPath": "skills/dotnet-core-expert/SKILL.md",
       "computedHash": "5264032693914801349de087dd9edbc3423f7607c2e5d9ce26704a9a2b236c01"
     },
+    "playwright-cli": {
+      "source": "microsoft/playwright-cli",
+      "sourceType": "github",
+      "skillPath": "skills/playwright-cli/SKILL.md",
+      "computedHash": "a07462654e72ec3b463aa0f3af744c320c57808505abe49e44845436e0050a1a"
+    },
     "requesting-code-review": {
       "source": "obra/superpowers",
       "sourceType": "github",

--- a/PomodoroFocus/test-results/.last-run.json
+++ b/PomodoroFocus/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,67 @@
+import { spawn, execSync } from 'child_process';
+import { chromium } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PORT = 5294;
+const URL = `http://localhost:${PORT}`;
+const TIMEOUT_MS = 60000;
+
+function isPortInUse(port: number): boolean {
+  try {
+    execSync(`netstat -ano | findstr :${port}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function waitForUrl(url: string, timeout: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = async () => {
+      try {
+        const response = await fetch(url);
+        if (response.ok) {
+          resolve();
+          return;
+        }
+      } catch { }
+      if (Date.now() - start > timeout) {
+        reject(new Error(`Timeout waiting for ${url}`));
+        return;
+      }
+      setTimeout(check, 1000);
+    };
+    check();
+  });
+}
+
+export default async () => {
+  const pidFile = path.join(__dirname, '.webapp.pid');
+
+  if (isPortInUse(PORT)) {
+    console.log(`Port ${PORT} already in use, assuming app is running.`);
+    return;
+  }
+
+  console.log('Starting PomodoroFocus.Web on port 5294...');
+
+  const projectRoot = path.join(__dirname, '..', '..', '..');
+  const webProject = path.join(projectRoot, 'PomodoroFocus', 'PomodoroFocus.Web');
+
+  const child = spawn('dotnet', ['run', '--project', webProject], {
+    detached: true,
+    stdio: 'ignore',
+    shell: true,
+    cwd: projectRoot,
+  });
+
+  child.unref();
+
+  fs.writeFileSync(pidFile, String(child.pid));
+
+  console.log(`Waiting for ${URL} to be ready...`);
+  await waitForUrl(URL, TIMEOUT_MS);
+  console.log('App is ready.');
+};

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,38 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PORT = 5294;
+
+function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(`netstat -ano | findstr :${port}`, { encoding: 'utf8' });
+    const lines = output.trim().split('\n');
+    for (const line of lines) {
+      const parts = line.trim().split(/\s+/);
+      const pidIndex = parts.length - 1;
+      const pid = parseInt(parts[pidIndex], 10);
+      if (pid && pid > 0) {
+        try {
+          execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+          console.log(`Killed process ${pid} on port ${port}`);
+        } catch { }
+      }
+    }
+  } catch { }
+}
+
+export default async () => {
+  const pidFile = path.join(__dirname, '.webapp.pid');
+
+  if (fs.existsSync(pidFile)) {
+    const pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10);
+    try {
+      execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+      console.log(`Killed webapp process ${pid}`);
+    } catch { }
+    fs.unlinkSync(pidFile);
+  }
+
+  killProcessOnPort(PORT);
+};

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pomodoro-focus-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "E2E tests for PomodoroFocus using Playwright",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^25.6.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:5294',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
+});

--- a/tests/e2e/pomodoro-flows.spec.ts
+++ b/tests/e2e/pomodoro-flows.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Pomodoro Timer - Initial Load (UC-07)', () => {
+  test('should load page with correct initial state', async ({ page }) => {
+    const url = `/?t=${Date.now()}-${Math.random()}`;
+    await page.goto(url);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: 'Pomodoro Focus!' })).toBeVisible();
+
+    const timerText = page.locator('.timer-text-overlay');
+    await expect(timerText).toBeVisible();
+    await expect(timerText).toHaveText('25:00');
+
+    await expect(page.getByRole('button', { name: 'Iniciar Pomodoro' })).toBeVisible();
+  });
+});
+
+test.describe('Pomodoro Timer - Start, Pause, Resume (UC-01, UC-02)', () => {
+  test('should start timer and show pause/cancel buttons', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+
+    await expect(page.getByRole('button', { name: 'Pausar' })).toBeVisible();
+    await expect(page.locator('.timer-controls .btn-danger')).toBeVisible();
+  });
+
+  test('should pause and resume timer', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+    await page.waitForTimeout(1500);
+
+    await page.getByRole('button', { name: 'Pausar' }).click();
+
+    await expect(page.getByRole('button', { name: 'Reanudar' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Reanudar' }).click();
+
+    await expect(page.getByRole('button', { name: 'Pausar' })).toBeVisible();
+  });
+});
+
+test.describe('Pomodoro Timer - Cancel (UC-03, UC-04)', () => {
+  test('should show cancel confirmation modal and discard session', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+    await page.waitForTimeout(1000);
+    await page.locator('.timer-controls .btn-danger').click();
+
+    const modal = page.locator('.modal-backdrop.visible');
+    await expect(modal).toBeVisible();
+
+    await expect(modal.getByRole('button', { name: 'Sí, marcar como completado' })).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'No, descartar sesión' })).toBeVisible();
+
+    await modal.getByRole('button', { name: 'No, descartar sesión' }).click();
+
+    await expect(modal).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Iniciar Pomodoro' })).toBeVisible();
+  });
+
+  test('should mark pomodoro as completed when confirmed', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+    await page.waitForTimeout(1000);
+    await page.locator('.timer-controls .btn-danger').click();
+
+    const modal = page.locator('.modal-backdrop.visible');
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole('button', { name: 'Sí, marcar como completado' }).click();
+
+    await expect(page.locator('.dot.active')).toHaveCount(1);
+  });
+});
+
+test.describe('Pomodoro Timer - Break Buttons (UC-05, UC-06)', () => {
+  test('should show break buttons after completing a pomodoro', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+    await page.waitForTimeout(1000);
+    await page.locator('.timer-controls .btn-danger').click();
+    await page.locator('.modal-backdrop.visible').getByRole('button', { name: 'Sí, marcar como completado' }).click();
+
+    await expect(page.getByRole('button', { name: 'Iniciar Descanso Corto' })).toBeVisible();
+  });
+
+  test('should start short break', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+    await page.waitForTimeout(1000);
+    await page.locator('.timer-controls .btn-danger').click();
+    await page.locator('.modal-backdrop.visible').getByRole('button', { name: 'Sí, marcar como completado' }).click();
+
+    await page.getByRole('button', { name: 'Iniciar Descanso Corto' }).click();
+
+    await expect(page.getByRole('button', { name: 'Pausar' })).toBeVisible();
+    await expect(page.locator('.timer-controls .btn-danger')).toBeVisible();
+  });
+});

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Settings - Configure Times (UC-08)', () => {
+  test('should open settings modal and close it', async ({ page }) => {
+    const url = `/?t=${Date.now()}-${Math.random()}`;
+    await page.goto(url);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await page.getByRole('button', { name: 'Configurar tiempos' }).click();
+
+    const modal = page.locator('.modal-backdrop.visible');
+    await expect(modal).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Configurar Tiempos/i })).toBeVisible();
+
+    await modal.locator('.close-btn').last().click();
+    await expect(modal).not.toBeVisible();
+  });
+
+  test('should save new timer configuration', async ({ page }) => {
+    const url = `/?t=${Date.now()}-${Math.random()}`;
+    await page.goto(url);
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await page.getByRole('button', { name: 'Configurar tiempos' }).click();
+
+    const modal = page.locator('.modal-backdrop.visible');
+    await expect(modal).toBeVisible();
+
+    await page.locator('#pomodoro-duration').selectOption('15');
+    await page.locator('#short-break').selectOption('3');
+    await page.locator('#long-break').selectOption('10');
+
+    await modal.getByRole('button', { name: 'Guardar' }).click();
+
+    await expect(modal).not.toBeVisible();
+
+    const timerText = page.locator('.timer-text-overlay');
+    await expect(timerText).toHaveText('15:00');
+  });
+
+  test('should disable settings button when timer is running', async ({ page }) => {
+    await page.goto(`/?t=${Date.now()}`);
+
+    await page.getByRole('button', { name: 'Iniciar Pomodoro' }).click();
+
+    const settingsButton = page.getByRole('button', { name: 'Configurar tiempos' });
+    await expect(settingsButton).toBeDisabled();
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Install @playwright/cli (global) + @playwright/test (local) for E2E testing
- Add playwright-cli skill for browser automation and UI testing
- Update qa-engineer agent to include playwright-cli integration and workflow
- Add 10 E2E tests covering UC-01 to UC-08 (pomodoro flows, settings)
- Fix PomodoroService to initialize RemainingSeconds on startup (25:00)
- Fix PomodoroService to update RemainingSeconds when config changes
- Add SetRemainingSeconds method to PomodoroSession
- Add .gitignore with node_modules, test-results, .agents, skills-lock