### PR TITLE
fix: corregir ruta de salida del publish de Blazor WASM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet test --no-build --configuration Release
 
       - name: Publish Blazor WASM
-        run: dotnet publish PomodoroFocus/PomodoroFocus.Web/PomodoroFocus.Web.csproj -c Release -o release/wwwroot --no-build
+        run: dotnet publish PomodoroFocus/PomodoroFocus.Web/PomodoroFocus.Web.csproj -c Release -o release --no-build
 
       - name: Rewrite base href and add SPA fallback for GitHub Pages
         run: |


### PR DESCRIPTION
La flag -o release/wwwroot colocaba los archivos estáticos en release/wwwroot/wwwroot/, rompiendo el rewrite de base href y el upload de Pages. Con -o release los archivos quedan en release/wwwroot/ como esperan los pasos siguientes.