### PR TITLE
fix: añadir working-directory a pasos de dotnet en el workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,15 +39,19 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
+        working-directory: PomodoroFocus
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
+        working-directory: PomodoroFocus
 
       - name: Run tests
         run: dotnet test --no-build --configuration Release
+        working-directory: PomodoroFocus
 
       - name: Publish Blazor WASM
-        run: dotnet publish PomodoroFocus/PomodoroFocus.Web/PomodoroFocus.Web.csproj -c Release -o release --no-build
+        run: dotnet publish PomodoroFocus.Web/PomodoroFocus.Web.csproj -c Release -o ../release --no-build
+        working-directory: PomodoroFocus
 
       - name: Rewrite base href and add SPA fallback for GitHub Pages
         run: |


### PR DESCRIPTION
Los proyectos están bajo PomodoroFocus/ y no en la raíz, por lo que dotnet restore/build/test/publish fallaban con MSB1003. Se agrega working-directory: PomodoroFocus a cada paso y se ajusta la ruta de publish a ../release para que el output quede en la raíz del repo.