### PR TITLE
fix: excluir tests E2E del pipeline de CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: PomodoroFocus
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Release
+        run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName!~.E2E."
         working-directory: PomodoroFocus
 
       - name: Publish Blazor WASM


### PR DESCRIPTION
Los tests E2E de Playwright requieren un servidor corriendo en localhost:5294 y binarios de browser, ninguno disponible en el runner de CI. Se filtran por namespace (.E2E.) para que solo corran los tests unitarios en el pipeline de deploy.