### PR TITLE
fix: corregir dotnet.js y añadir bootstrap para GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,11 +53,11 @@ jobs:
         run: dotnet publish PomodoroFocus.Web/PomodoroFocus.Web.csproj -c Release -o ../release -p:CompressionEnabled=false
         working-directory: PomodoroFocus
 
-      - name: List publish output (debug)
+      - name: Prepare static assets for GitHub Pages
         run: |
-          echo "=== release/ ===" && ls release/
-          echo "=== release/wwwroot/ ===" && ls release/wwwroot/
-          echo "=== release/wwwroot/_framework/ ===" && ls release/wwwroot/_framework/ | head -30
+          cp release/dotnet.js release/wwwroot/_framework/dotnet.js
+          mkdir -p release/wwwroot/css/bootstrap
+          curl -sL "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" -o release/wwwroot/css/bootstrap/bootstrap.min.css
 
       - name: Rewrite base href and add SPA fallback for GitHub Pages
         run: |

--- a/PomodoroFocus/PomodoroFocus.Web/libman.json
+++ b/PomodoroFocus/PomodoroFocus.Web/libman.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "defaultProvider": "jsdelivr",
+  "libraries": [
+    {
+      "provider": "jsdelivr",
+      "library": "bootstrap@5.3.3",
+      "destination": "wwwroot/css/bootstrap",
+      "files": [
+        "bootstrap.min.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
En .NET 10, dotnet.js se publica en la raíz del output en lugar de wwwroot/_framework/, por lo que hay que copiarlo antes del deploy.

Bootstrap nunca fue incluido en el proyecto; se agrega libman.json para dev local y se descarga en CI desde jsDelivr.